### PR TITLE
[Feat] 콘텐츠 공유 기능 구현 (#99)

### DIFF
--- a/grow-snap-frontend/src/hooks/useFeed.ts
+++ b/grow-snap-frontend/src/hooks/useFeed.ts
@@ -488,9 +488,10 @@ export function useFeed(options: UseFeedOptions) {
         if (result.action === Share.sharedAction) {
           shareMutation.mutate(contentId);
         }
-      } catch (error: any) {
-        // 사용자가 공유를 취소한 경우는 에러로 처리하지 않음
-        if (error?.message?.includes('User did not share')) {
+      } catch (error: unknown) {
+        // 사용자가 공유를 취소한 경우는 에러로 처리하지 않음 (Android)
+        // 참고: 이 에러 메시지는 React Native 버전에 따라 변경될 수 있습니다.
+        if (error instanceof Error && error.message.includes('User did not share')) {
           return;
         }
         console.error('Share failed:', error);


### PR DESCRIPTION
  ### 작업 내용
  React Native Share API를 사용하여 콘텐츠 공유 기능을 구현했습니다. 피드, 카테고리, 프로필, 검색 모든 화면에서 네이티브 공유 시트를 통해 콘텐츠를 공유할 수 있으며, 공유 카운터는 낙관적 업데이트로 즉시 반영됩니다.

  ---

  ### 관련 이슈
  Closes #99

  ---

  ### 작업 사항

  #### Frontend - useFeed.ts
  - **Share mutation 추가 (낙관적 업데이트)**
    - `shareMutation`: 공유 성공 시 shareCount 즉시 증가
    - `onMutate`: 낙관적 UI 업데이트 (즉시 피드백)
    - `onSuccess`: 백엔드 응답으로 실제 count 동기화
    - `onError`: 에러 발생 시 이전 상태로 롤백

  - **handleShare 구현**
    - `getShareLink()`: 백엔드에서 공유 링크 가져오기
    - `Share.share()`: 네이티브 공유 시트 열기
    - 공유 성공(`Share.sharedAction`) 시에만 카운터 증가
    - 사용자 취소는 조용히 무시, 에러는 Alert 표시

  - **Import 추가**
    - React Native `Share`, `Alert`
    - `getShareLink` from share.api

  #### Frontend - ContentViewerScreen.tsx
  - **프로필/검색 화면에서도 공유 기능 활성화**
    - Share mutation 추가 (useFeed와 동일 패턴)
    - handleShare 구현 (네이티브 공유 시트)
    - 공유 성공 시 콘텐츠 상세 정보 업데이트

  #### 공유 메시지 형식
  GrowSnap에서 흥미로운 콘텐츠를 발견했어요! 같이 봐요 😊

  https://growsnap.com/watch/{contentId}

  ---

  ### 테스트
  - [x] 로컬 테스트 완료
  - [x] TypeScript 컴파일 확인 (에러 없음)
  - [ ] 실제 디바이스 테스트 (공유 시트 확인 필요)

  **테스트 시나리오:**
  1. ✅ 피드 탭 → 공유 버튼 → 네이티브 공유 시트 확인
  2. ✅ 카테고리 탭 → 공유 버튼 → 네이티브 공유 시트 확인
  3. ✅ 프로필 → 콘텐츠 클릭 → 공유 버튼 → 네이티브 공유 시트 확인
  4. ✅ 검색 → 쇼츠 클릭 → 공유 버튼 → 네이티브 공유 시트 확인
  5. ✅ 공유 카운터 증가 확인 (낙관적 업데이트)
  6. ✅ 공유 취소 시 카운터 유지 확인

  ---

  ### 스크린샷 (UI 변경 시)
  해당 없음 (UI 변경 없음, 기능 추가)

  ---

  ### 참고 사항

  #### 주요 구현 사항
  - **낙관적 업데이트(Optimistic Update)**: Like/Save와 동일한 패턴
  적용
    - 공유 버튼 클릭 시 즉시 shareCount 증가 (빠른 피드백)
    - 백엔드 응답 후 실제 count로 동기화
    - 에러 발생 시 자동 롤백

  - **네이티브 공유 시트**: React Native Share API 사용
    - iOS: UIActivityViewController
    - Android: Intent.ACTION_SEND
    - 공유 성공 시에만 백엔드 API 호출 (불필요한 요청 방지)

  - **에러 처리**
    - 사용자 취소: 조용히 무시 (에러 없음)
    - 네트워크 오류: "공유 실패, 잠시 후 다시 시도해주세요" Alert

  #### 딥링크 (Deep Link) 관련
  현재 공유 링크는 웹
  URL(`https://growsnap.com/watch/{contentId}`)이며, 클릭 시
  브라우저로 이동합니다. 앱으로 자동 이동하려면 Universal Links(iOS)
  및 App Links(Android) 설정이 필요합니다.

  - **Issue #100으로 분리**: [Frontend/Backend] Universal Links & App
  Links 딥링크 구현 (P2)
  - **현재 상태**: 공유 기능 자체는 정상 작동, 링크는 브라우저로 열림
  - **향후 작업**: 도메인 확보 후 `.well-known/` 파일 배포 및 앱 설정

  #### 성능 최적화
  - React Query의 낙관적 업데이트로 즉각적인 UI 반응
  - 공유 성공 시에만 백엔드 API 호출 (불필요한 네트워크 요청 최소화)
  - `useCallback`으로 함수 재생성 방지

  #### 코드 변경 통계
  - **변경 파일**: 2개
    - `useFeed.ts`: +92줄, -8줄
    - `ContentViewerScreen.tsx`: +42줄, -4줄
  - **총 변경**: +134줄, -12줄

  ---

  ### 체크리스트
  - [x] [Git Convention](../docs/GIT_CONVENTION.md) 준수
  - [x] 코드 리뷰 준비 완료
  - [x] Breaking Change 없음
  - [x] 기존 기능에 영향 없음
  - [x] 모든 화면에서 공유 기능 작동 확인