### PR TITLE
[Fix] 업로드 화면 미디어 라이브러리 캐시 문제 해결 (#96)

### DIFF
--- a/grow-snap-frontend/src/screens/upload/UploadMainScreen.tsx
+++ b/grow-snap-frontend/src/screens/upload/UploadMainScreen.tsx
@@ -7,7 +7,7 @@
  * - 카메라 버튼이 그리드 첫 번째 위치
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -45,6 +45,7 @@ export default function UploadMainScreen({ navigation }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [currentPreviewIndex, setCurrentPreviewIndex] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  const isInitialFocus = useRef(true);
 
   useEffect(() => {
     requestPermissions();
@@ -57,8 +58,14 @@ export default function UploadMainScreen({ navigation }: Props) {
   }, [hasPermission, contentType]);
 
   // 화면 포커스 시 미디어 라이브러리 자동 새로고침
+  // 첫 마운트 시에는 실행하지 않아 useEffect와의 중복 호출 방지
   useFocusEffect(
     useCallback(() => {
+      if (isInitialFocus.current) {
+        isInitialFocus.current = false;
+        return;
+      }
+
       if (hasPermission) {
         loadMediaAssets();
       }


### PR DESCRIPTION
  ### 작업 내용
  업로드 화면에서 카메라 앱으로 사진/영상 촬영 후 돌아올 때 새로운 미디어가 자동으로 표시되도록 개선했습니다.

  ---

  ### 관련 이슈
  Closes #96

  ---

  ### 작업 사항
  - **useFocusEffect 추가**
    - 화면에 포커스될 때마다 미디어 라이브러리 자동 새로고침
    - useCallback으로 메모이제이션하여 성능 최적화

  - **Pull-to-Refresh 기능 추가**
    - RefreshControl을 FlatList에 추가
    - 사용자가 수동으로 새로고침 가능
    - 테마 컬러 적용

  ---

  ### 테스트
  - [x] TypeScript 타입 체크 통과
  - [x] Clean Build 성공 (20분)
  - [x] 기존 코드와의 호환성 확인

  ---

  ### 스크린샷 (UI 변경 시)
  해당 없음 (UI 변경 없음, 동작 개선)

  ---

  ### 참고 사항

  #### 기술적 세부사항
  - React Navigation의 `useFocusEffect` 훅 사용
  - `hasPermission`과 `contentType`을 의존성 배열에 포함하여 필요
  시에만 새로고침
  - Pull-to-Refresh는 Android/iOS 모두 네이티브 컴포넌트 사용

  #### 성능 최적화
  - useCallback으로 함수 메모이제이션
  - 불필요한 리렌더링 방지

  ---

  ### 체크리스트
  - [x] [Git Convention](../.claude/skills/git.md) 준수
  - [x] 코드 리뷰 준비 완료
  - [x] Breaking Change 없음