### PR TITLE
[Feat] 콘텐츠 차단 후 자동으로 다음 콘텐츠로 이동 (#97)

### DIFF
--- a/grow-snap-frontend/src/components/feed/FeedItem.tsx
+++ b/grow-snap-frontend/src/components/feed/FeedItem.tsx
@@ -42,6 +42,7 @@ interface FeedItemProps {
   onShare?: () => void;
   onFollow?: () => void;
   onCreatorPress?: () => void;
+  onBlockSuccess?: () => void; // 차단 성공 시 호출
 }
 
 export const FeedItem: React.FC<FeedItemProps> = ({
@@ -56,6 +57,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
   onShare,
   onFollow,
   onCreatorPress,
+  onBlockSuccess,
 }) => {
   const tabBarHeight = useSafeBottomTabBarHeight();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -196,6 +198,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
         onShare={onShare}
         onFollow={onFollow}
         onCreatorPress={onCreatorPress}
+        onBlockSuccess={onBlockSuccess}
         isExpanded={isExpanded}
         setIsExpanded={setIsExpanded}
         tabBarHeight={tabBarHeight}

--- a/grow-snap-frontend/src/components/feed/FeedOverlay.tsx
+++ b/grow-snap-frontend/src/components/feed/FeedOverlay.tsx
@@ -33,6 +33,7 @@ interface FeedOverlayProps {
   onShare?: () => void;
   onFollow?: () => void;
   onCreatorPress?: () => void;
+  onBlockSuccess?: () => void; // 차단 성공 시 호출
   isExpanded: boolean;
   setIsExpanded: (expanded: boolean) => void;
   tabBarHeight: number;
@@ -58,6 +59,7 @@ export const FeedOverlay: React.FC<FeedOverlayProps> = ({
   onShare,
   onFollow,
   onCreatorPress,
+  onBlockSuccess,
   isExpanded,
   setIsExpanded,
   tabBarHeight,
@@ -307,8 +309,8 @@ export const FeedOverlay: React.FC<FeedOverlayProps> = ({
           targetId={blockType === 'user' ? creator.userId : contentId}
           targetName={blockType === 'user' ? creator.nickname : title}
           onSuccess={() => {
-            // 차단 성공 시 피드에서 제거 (부모 컴포넌트에서 처리)
-            // 여기서는 모달만 닫음
+            // 차단 성공 시 다음 콘텐츠로 자동 스크롤 (Instagram/TikTok 스타일)
+            onBlockSuccess?.();
           }}
         />
 

--- a/grow-snap-frontend/src/hooks/useFeed.ts
+++ b/grow-snap-frontend/src/hooks/useFeed.ts
@@ -515,6 +515,20 @@ export function useFeed(options: UseFeedOptions) {
     [navigation]
   );
 
+  // 차단 성공 후 다음 콘텐츠로 자동 스크롤 (Instagram/TikTok 스타일)
+  const handleBlockSuccess = useCallback(() => {
+    const nextIndex = currentIndex + 1;
+
+    // 다음 콘텐츠가 있으면 스크롤
+    if (nextIndex < displayItems.length) {
+      flatListRef.current?.scrollToIndex({
+        index: nextIndex,
+        animated: true, // 부드러운 전환 애니메이션
+      });
+    }
+    // 마지막 콘텐츠를 차단한 경우는 그대로 유지 (사용자가 스와이프하여 이동)
+  }, [currentIndex, displayItems.length]);
+
   // Video 로드 완료 콜백
   const handleVideoLoaded = useCallback((contentId: string) => {
     videoLoadedCache.current.set(contentId, true);
@@ -624,6 +638,7 @@ export function useFeed(options: UseFeedOptions) {
     handleShare,
     handleFollow,
     handleCreatorPress,
+    handleBlockSuccess,
 
     // Video 관리
     handleVideoLoaded,

--- a/grow-snap-frontend/src/screens/explore/CategoryFeedScreen.tsx
+++ b/grow-snap-frontend/src/screens/explore/CategoryFeedScreen.tsx
@@ -62,6 +62,7 @@ export default function CategoryFeedScreen() {
     handleShare,
     handleFollow,
     handleCreatorPress,
+    handleBlockSuccess,
     handleVideoLoaded,
     isVideoLoaded,
     handleScroll,
@@ -99,6 +100,7 @@ export default function CategoryFeedScreen() {
           onShare={() => handleShare(item.contentId)}
           onFollow={() => handleFollow(item.creator.userId, item.creator.isFollowing ?? false)}
           onCreatorPress={() => handleCreatorPress(item.creator.userId)}
+          onBlockSuccess={handleBlockSuccess}
         />
 
         {isLoadingItem && (

--- a/grow-snap-frontend/src/screens/feed/FeedScreen.tsx
+++ b/grow-snap-frontend/src/screens/feed/FeedScreen.tsx
@@ -57,6 +57,7 @@ export default function FeedScreen() {
     handleShare,
     handleFollow,
     handleCreatorPress,
+    handleBlockSuccess,
     handleVideoLoaded,
     isVideoLoaded,
     clearVideoCache,
@@ -127,6 +128,7 @@ export default function FeedScreen() {
           onShare={() => handleShare(item.contentId)}
           onFollow={() => handleFollow(item.creator.userId, item.creator.isFollowing ?? false)}
           onCreatorPress={() => handleCreatorPress(item.creator.userId)}
+          onBlockSuccess={handleBlockSuccess}
         />
 
         {isLoadingItem && (


### PR DESCRIPTION
  ### 작업 내용
  Instagram Reels/TikTok 스타일로 콘텐츠 차단 후 자동으로 다음 콘텐츠로 넘어가는 기능을 구현했습니다. 사용자가 "이 콘텐츠 관심없음" 또는 "사용자 차단하기"를 선택하면 차단된 콘텐츠가 화면에 남지 않고 부드럽게 다음 콘텐츠로 스크롤됩니다.

  ---

  ### 관련 이슈
  Closes #97

  ---

  ### 작업 사항
  - **useFeed 훅에 자동 스크롤 로직 추가**
    - `handleBlockSuccess` 함수 구현
    - 차단 성공 시 다음 인덱스로 자동 스크롤 (`animated: true`)
    - 마지막 콘텐츠 차단 시 스크롤하지 않고 유지

  - **Props 체인 연결**
    - `FeedItem`에 `onBlockSuccess` prop 추가
    - `FeedOverlay`에 `onBlockSuccess` 전달
    - `BlockConfirmModal`의 `onSuccess`에 연결

  - **적용 화면**
    - `FeedScreen` (추천/팔로잉 피드)
    - `CategoryFeedScreen` (카테고리 피드)

  ---

  ### 테스트
  - [ ] 로컬 테스트 완료
  - [ ] 단위 테스트 작성/통과
  - [ ] 통합 테스트 통과 (해당 시)

  ---

  ### 스크린샷 (UI 변경 시)
  동작 테스트 후 추가 예정

  ---

  ### 참고 사항

  #### 동작 방식
  1. 사용자가 "이 콘텐츠 관심없음" 또는 "사용자 차단하기" 선택
  2. `BlockConfirmModal`에서 차단 확인
  3. 차단 성공 시 `onBlockSuccess` 콜백 호출
  4. 다음 인덱스가 존재하면 `FlatList.scrollToIndex`로 부드럽게 스크롤
  5. 마지막 콘텐츠인 경우 스크롤하지 않고 그대로 유지

  #### 주요 변경사항
  - **파일 수정**: 5개 파일 (useFeed.ts, FeedItem.tsx,
  FeedOverlay.tsx, FeedScreen.tsx, CategoryFeedScreen.tsx)
  - **코드 변경**: +26줄 추가, -2줄 삭제
  - **애니메이션**: 부드러운 전환을 위해 `animated: true` 옵션 사용

  #### 엣지 케이스 처리
  - 마지막 콘텐츠를 차단한 경우: 스크롤하지 않고 그대로 유지 (사용자가
   수동으로 스와이프)
  - 차단된 콘텐츠는 displayItems에 남아있지만 다음 콘텐츠로 이동

  ---

  ### 체크리스트
  - [x] [Git Convention](../docs/GIT_CONVENTION.md) 준수
  - [x] 코드 리뷰 준비 완료
  - [x] Breaking Change 없음