### PR TITLE
[Feat] manifest-ops 디렉토리 구축 - Kubernetes Manifests (ISSUE-125)

### DIFF
--- a/manifest-ops/prod/ingress.yaml
+++ b/manifest-ops/prod/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: upvy-backend-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,Accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "86400"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.upvy.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: upvy-backend-prod-svc
+                port:
+                  number: 8080

--- a/manifest-ops/prod/otel-collector-config.yaml
+++ b/manifest-ops/prod/otel-collector-config.yaml
@@ -1,0 +1,186 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+data:
+  config.yaml: |
+    receivers:
+      # OTLP receiver for traces, metrics, and logs from Java agents
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    
+    processors:
+      # Batch processor for performance optimization
+      batch:
+        timeout: 1s
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+
+      # Memory limiter to prevent OOM
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+
+      # Transform logs to set indexed labels
+      transform/logs:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              # Forward log level to resource attributes for Loki indexing
+              - set(resource.attributes["severity.text"], severity_text)
+              - set(resource.attributes["severity.number"], severity_number)
+
+      # K8s attributes extraction
+      k8sattributes:
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.node.name
+            - k8s.container.name
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: connection
+      attributes:
+        actions:
+          # Add trace context to logs for correlation
+          - key: "trace_id"
+            from_context: "trace_id"
+            action: "insert"
+          - key: "span_id"
+            from_context: "span_id"
+            action: "insert"
+          # Add severity_text as indexed label for Loki
+          - key: "severity_text"
+            from_attribute: "severity_text"
+            action: "upsert"
+      resource:
+        attributes:
+          # Ensure service.name is preserved from OTEL agent
+          - key: service.name
+            from_attribute: service.name
+            action: upsert
+          - key: service.namespace
+            value: "default"
+            action: upsert
+          # Common labels for correlation across metrics, traces, and logs
+          - key: environment
+            value: "prod"
+            action: upsert
+          - key: deployment.environment
+            value: "prod"
+            action: upsert
+          - key: deployment.environment.name
+            value: "prod"
+            action: upsert
+          - key: namespace
+            value: "default"
+            action: upsert
+          - key: service.instance.id
+            from_attribute: service.instance.id
+            action: upsert
+          - key: pod
+            from_attribute: host.name
+            action: upsert
+          - key: container
+            value: "app"
+            action: upsert
+          - key: k8s.namespace.name
+            value: "default"
+            action: upsert
+          - key: k8s.pod.name
+            from_attribute: host.name
+            action: upsert
+    
+    exporters:
+      otlp/tempo:
+        endpoint: "http://tempo-prod-svc.monitoring.svc.cluster.local:4317"
+        tls:
+          insecure: true
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+      prometheusremotewrite:
+        endpoint: "http://prometheus-prod-svc.monitoring.svc.cluster.local:9090/prometheus/api/v1/write"
+        tls:
+          insecure: true
+        resource_to_telemetry_conversion:
+          enabled: true
+        target_info:
+          enabled: true
+        add_metric_suffixes: true
+        send_metadata: true
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+      otlphttp/loki:
+        endpoint: "http://loki-prod-svc.monitoring.svc.cluster.local:3100/otlp"
+        headers:
+          "X-Scope-OrgID": "default"
+        tls:
+          insecure: true
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+      # Debug exporter for troubleshooting
+      debug:
+        verbosity: detailed
+        sampling_initial: 5
+        sampling_thereafter: 200
+
+    extensions:
+      # Health check extension
+      health_check:
+        endpoint: 0.0.0.0:13133
+      # Performance profiling extension
+      pprof:
+        endpoint: 0.0.0.0:1777
+      # zPages extension for debugging
+      zpages:
+        endpoint: 0.0.0.0:55679
+
+    service:
+      extensions: [health_check, pprof, zpages]
+
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, resource, k8sattributes, batch]
+          exporters: [otlp/tempo, debug]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, resource, k8sattributes, batch]
+          exporters: [prometheusremotewrite, debug]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, resource, k8sattributes, attributes, transform/logs, batch]
+          exporters: [otlphttp/loki, debug]
+
+      telemetry:
+        logs:
+          level: info
+          initial_fields:
+            service: "otel-collector"
+        metrics:
+          level: detailed
+          address: 0.0.0.0:8888

--- a/manifest-ops/prod/upvy-backend/deployment.yaml
+++ b/manifest-ops/prod/upvy-backend/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upvy-backend-prod
+  labels:
+    app: upvy-backend-prod
+spec:
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: upvy-backend-prod
+  template:
+    metadata:
+      labels:
+        app: upvy-backend-prod
+    spec:
+      imagePullSecrets:
+        - name: bootalk-gcp-docker-secret
+      nodeSelector:
+        node-pool: default
+      serviceAccountName: otel-collector
+      securityContext:
+        runAsUser: 2000
+        runAsNonRoot: true
+        fsGroup: 2000
+      initContainers:
+        - name: otel-agent-downloader
+          image: curlimages/curl:8.7.1
+          command:
+            - sh
+            - -c
+            - curl -sSL -o /otel/opentelemetry-javaagent.jar https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.20.1/opentelemetry-javaagent.jar
+          volumeMounts:
+            - name: otel-agent
+              mountPath: /otel
+      containers:
+        - name: upvy-backend-prod
+          image: image-example:tag-example
+          env:
+            - name: SPRING_APPLICATION_JSON
+              value: '{ "server.port": 8080, "spring.profiles.active": "prod" }'
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://localhost:4317
+            - name: OTEL_SERVICE_NAME
+              value: upvy-service
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: deployment.environment=prod
+            - name: JAVA_TOOL_OPTIONS
+              value: >-
+                -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:MinRAMPercentage=50.0 -XX:MaxRAMPercentage=80.0 -XX:+AlwaysPreTouch -javaagent:/otel/opentelemetry-javaagent.jar -Dotel.javaagent.enabled=true -Dotel.metrics.exporter=otlp -Dotel.traces.exporter=otlp -Dotel.logs.exporter=otlp -Dotel.exporter.otlp.endpoint=http://localhost:4317 -Dotel.exporter.otlp.protocol=grpc -Dotel.exporter.otlp.metrics.temporality.preference=CUMULATIVE -Dotel.instrumentation.logging.auto-attributes.enabled=true -Dotel.instrumentation.logback-appender.enabled=true -Dotel.instrumentation.log4j-appender.enabled=true -Dotel.instrumentation.log4j-context-data.enabled=true -Dotel.instrumentation.logback-mdc.enabled=true -Dotel.instrumentation.micrometer.enabled=true -Dotel.instrumentation.spring-boot-actuator.enabled=true -Dotel.instrumentation.jdbc.enabled=true -Dotel.instrumentation.kafka.enabled=true -Dotel.instrumentation.redis.enabled=true -Dotel.instrumentation.mongodb.enabled=true -Dotel.instrumentation.spring-webmvc.enabled=true -Dotel.instrumentation.spring-webflux.enabled=true -Dotel.instrumentation.tomcat.enabled=true -Dotel.instrumentation.runtime-telemetry.enabled=true -Dotel.instrumentation.process.experimental.enabled=true -Dotel.instrumentation.common.default-enabled=true
+          volumeMounts:
+            - name: otel-agent
+              mountPath: /otel
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 200m
+              memory: 300Mi
+            limits:
+              cpu: 400m
+              memory: 600Mi
+          securityContext:
+            runAsUser: 2000
+            runAsNonRoot: true
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.98.0
+          args:
+            - "--config=/etc/otel/config.yaml"
+          ports:
+            - containerPort: 4317
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: otel-config
+              mountPath: /etc/otel
+      volumes:
+        - name: otel-agent
+          emptyDir: {}
+        - name: otel-config
+          configMap:
+            name: otel-collector-config

--- a/manifest-ops/prod/upvy-backend/hpa.yaml
+++ b/manifest-ops/prod/upvy-backend/hpa.yaml
@@ -1,0 +1,36 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: upvy-backend-prod-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: upvy-backend-prod
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 1
+          periodSeconds: 15
+      selectPolicy: Max
+---

--- a/manifest-ops/prod/upvy-backend/pdb.yaml
+++ b/manifest-ops/prod/upvy-backend/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: upvy-backend-prod-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: upvy-backend-prod
+---

--- a/manifest-ops/prod/upvy-backend/service.yaml
+++ b/manifest-ops/prod/upvy-backend/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: upvy-backend-prod-svc
+spec:
+  selector:
+    app: upvy-backend-prod
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
  ### 작업 내용
  Kubernetes 배포를 위한 manifest-ops 디렉토리를 구축했습니다. upvy-backend의 prod 환경 배포에 필요한 K8s 리소스를 정의했습니다.

  ---

  ### 관련 이슈
  Closes #125

  ---

  ### 작업 사항
  - **Ingress 설정**
    - `api.upvy.org` 호스트 라우팅
    - NGINX Ingress Controller 기반 CORS 설정
    - proxy-body-size 50m 설정

  - **upvy-backend Deployment**
    - OpenTelemetry Java Agent 자동 다운로드 (initContainer)
    - OTel Collector sidecar 패턴 적용
    - Liveness/Readiness/Startup Probe 설정
    - Security Context (non-root, runAsUser: 2000)

  - **HPA (Horizontal Pod Autoscaler)**
    - CPU 70% 기준 auto-scaling (2~10 replicas)
    - Scale-down stabilization 300초

  - **PDB (Pod Disruption Budget)**
    - minAvailable: 1

  - **OpenTelemetry Collector ConfigMap**
    - Traces → Tempo
    - Metrics → Prometheus Remote Write
    - Logs → Loki (OTLP)

  ---

  ### 테스트
  - [x] YAML 문법 검증
  - [ ] 클러스터 배포 테스트 (추후 진행)

  ---

  ### 스크린샷 (UI 변경 시)
  해당 없음 (인프라 작업)

  ---

  ### 참고 사항

  #### 디렉토리 구조
  manifest-ops/
  └── prod/
      ├── ingress.yaml
      ├── otel-collector-config.yaml
      └── upvy-backend/
          ├── deployment.yaml
          ├── hpa.yaml
          ├── pdb.yaml
          └── service.yaml

  #### 배포 명령어
  ```bash
  kubectl apply -f manifest-ops/prod/

  추후 작업
  - dev 환경 추가

  ---
  체크리스트

  - ../docs/GIT_CONVENTION.md 준수
  - 코드 리뷰 준비 완료
  - Breaking Change 없음