### PR TITLE
[Feat] iOS 사진 라이브러리 권한 설명 다국어 지원 (ISSUE-155)

### DIFF
--- a/upvy-frontend/app.config.js
+++ b/upvy-frontend/app.config.js
@@ -4,6 +4,15 @@
  * app.json을 app.config.js로 변환하여 동적 환경 변수 지원
  */
 
+// 권한 설명 문자열 상수
+const PERMISSION_STRINGS = {
+  NSPhotoLibraryUsageDescription: {
+    ko: 'Upvy는 사진 및 동영상 업로드를 위해 사진 라이브러리 접근 권한이 필요합니다.',
+    en: 'Upvy needs access to your photo library to select photos and videos for uploading and sharing.',
+    ja: 'Upvyは写真と動画のアップロードのため、フォトライブラリへのアクセス権限が必要です。',
+  },
+};
+
 module.exports = {
   expo: {
     name: 'Upvy',
@@ -24,8 +33,7 @@ module.exports = {
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
         UIViewControllerBasedStatusBarAppearance: true,
-        NSPhotoLibraryUsageDescription:
-          'Upvy needs access to your photo library to select photos and videos for uploading and sharing.',
+        NSPhotoLibraryUsageDescription: PERMISSION_STRINGS.NSPhotoLibraryUsageDescription.en,
       },
     },
     android: {
@@ -57,16 +65,13 @@ module.exports = {
         './plugins/withInfoPlistStrings',
         {
           ko: {
-            NSPhotoLibraryUsageDescription:
-              'Upvy는 사진 및 동영상 업로드를 위해 사진 라이브러리 접근 권한이 필요합니다.',
+            NSPhotoLibraryUsageDescription: PERMISSION_STRINGS.NSPhotoLibraryUsageDescription.ko,
           },
           en: {
-            NSPhotoLibraryUsageDescription:
-              'Upvy needs access to your photo library to select photos and videos for uploading and sharing.',
+            NSPhotoLibraryUsageDescription: PERMISSION_STRINGS.NSPhotoLibraryUsageDescription.en,
           },
           ja: {
-            NSPhotoLibraryUsageDescription:
-              'Upvyは写真と動画のアップロードのため、フォトライブラリへのアクセス権限が必要です。',
+            NSPhotoLibraryUsageDescription: PERMISSION_STRINGS.NSPhotoLibraryUsageDescription.ja,
           },
         },
       ],


### PR DESCRIPTION
  ### 작업 내용
  Apple App Store 심사 거부 대응을 위해 iOS 사진 라이브러리 권한 설명을 다국어로 구체화했습니다. Expo Config Plugin을 활용하여 한국어, 영어, 일본어로 권한 설명을 제공합니다.

  ---

  ### 관련 이슈
  Closes #155

  ---

  ### 작업 사항
  - **Expo Config Plugin 생성**
    - `plugins/withInfoPlistStrings.js`: InfoPlist.strings 파일 자동 생성
    - 언어별 .lproj 폴더에 권한 설명 파일 생성 (ko.lproj, en.lproj, ja.lproj)

  - **app.config.js 수정**
    - withInfoPlistStrings 플러그인 추가
    - 다국어 권한 설명 추가:
      - 한국어: "Upvy는 사진 및 동영상 업로드를 위해 사진 라이브러리 접근 권한이 필요합니다."
      - 영어: "Upvy needs access to your photo library to select photos and videos for uploading and sharing."
      - 일본어: "Upvyは写真と動画のアップロードのため、フォトライブラリへのアクセス権限が必要です。"

  - **권한 범위 최소화**
    - NSPhotoLibraryUsageDescription만 사용 (읽기 권한)
    - 앱이 사진 라이브러리에 저장하지 않으므로 NSPhotoLibraryAddUsageDescription 제외

  ---

  ### 테스트
  - [x] 로컬 빌드 확인 (iOS)
  - [x] 코드 검증 완료
  - [x] 다국어 번역 확인 (한국어, 영어, 일본어)

  ---

  ### 스크린샷 (UI 변경 시)
  해당 없음 (권한 설명 텍스트만 변경)

  ---

  ### 참고 사항

  #### 주요 변경사항
  - Apple Guideline 5.1.1 (Legal - Privacy) 준수
  - 기기 언어 설정에 따라 자동으로 권한 설명 표시
  - Config Plugin을 통한 빌드 시 자동 생성으로 수동 관리 불필요

  #### 기술 구현
  - `@expo/config-plugins`의 `withDangerousMod` 사용
  - iOS 빌드 시 `ios/{ProjectName}/{language}.lproj/InfoPlist.strings` 자동 생성
  - 사진과 비디오 모두 선택할 수 있음을 명시 (UploadMainScreen.tsx 확인)

  #### Apple 심사 거부 대응
  - Submission ID: b31b0dde-e61e-4062-85ba-6c092d82d732
  - 거부 사유: Purpose string 불충분
  - 해결: 구체적인 사용 목적 명시 + 다국어 지원

  ---

  ### 체크리스트
  - [x] [Git Convention](../docs/GIT_CONVENTION.md) 준수
  - [x] 코드 리뷰 준비 완료
  - [x] Breaking Change 없음